### PR TITLE
Added optional source url restrictions to Rule

### DIFF
--- a/scrapy/spiders/crawl.py
+++ b/scrapy/spiders/crawl.py
@@ -67,6 +67,8 @@ class CrawlSpider(Spider):
             return
         seen = set()
         for n, rule in enumerate(self._rules):
+            if not rule.source_allowed(response.url):
+                continue
             links = [lnk for lnk in rule.link_extractor.extract_links(response)
                      if lnk not in seen]
             if links and rule.process_links:


### PR DESCRIPTION
There is no easy way (that I can find) to restrict `Rule`s to specific response URLs [1]. For example, I may want to limit a `Rule` to only apply to a _response_ from a `category.php` page [2].  It _appears_ the current way to do this is to be overly specific with your link extractor's xpath so it only matches links on `category.php` pages.  This has the downside of being fragile and unprovable.

This PR:
- adds new `Rule` optional arguments `allow_sources` and `deny_sources` (mimicking the implementation of LinkExtractor's `allow` and `deny`)
- adds `Rule.source_allowed(url)` to check if url is allowed/denied
- `CrawlSpider._requests_to_follow` checks `Rule.source_allowed` for each rule
- Tests for above

[1] Example of someone else trying to solve this issue: http://stackoverflow.com/questions/22653656/how-to-make-rules-of-crawlspider-context-sensitive
[2] In my use case, I need to scrape a mix of ecommerce product pages, category pages & "super-category" pages.
